### PR TITLE
Prune repo tags one at a time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ deployment:
     - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
     - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev no-confirm-deploy
-    - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy
+    - $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production no-confirm-deploy
     branch: master
   non-master:
     owner: Clever


### PR DESCRIPTION
Previously, in the worst case, we could prune a bunch of images from DockerHub,
timeout, and then fail to delete any repos from ECR. This means that we would never
prune those image tags in ECR.

This approach is more robust at keeping ECR images cleaned up.