### PR TITLE
Set default min/max autoscaling counts for  prune-images

### DIFF
--- a/launch/prune-images.yml
+++ b/launch/prune-images.yml
@@ -5,18 +5,19 @@ aws:
   managed:
     clever:
     - Workflows
-env: 
-  - AWS_REGION
-  - DOCKERHUB_USERNAME
-  - DOCKERHUB_PASSWORD
-  - DRY_RUN
+env:
+- AWS_REGION
+- DOCKERHUB_USERNAME
+- DOCKERHUB_PASSWORD
+- DRY_RUN
 resources:
   cpu: 0
   max_mem: 0.1
 shepherds:
-- "vicky.enalen@clever.com"
+- vicky.enalen@clever.com
 expose: []
 team: eng-infra
 autoscaling:
   metric: active-percent
   metric_target: 70
+  max_count: 1


### PR DESCRIPTION
Merge at your lesure

The `autoscaling` section of launch yamls now support `min_count` and `max_count`.  Previously
those values were implicitly determined on the deployment count.  This is no longer the case.
Autoscaled and lambda limits are no longer determined by `ark scale`'d'.  Lambda cannot be scaled
and scaling an autoscaled app will force a deploy to the specified count until the next deploy occurs.

This PR backfills the min/max values of already deployed autoscaled apps.

Welcome to the exciting new world over high visibility autoscaling. :balloon:

Context:
- https://clever.atlassian.net/browse/INFRA-3003
