### PR TITLE
dev to podOnly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN apt-get update -y
 RUN apt-get install -y ca-certificates
 COPY bin/prune-images /usr/bin/prune-images
 COPY bin/sfncli /usr/bin/sfncli
-CMD ["/usr/bin/sfncli", "--activityname", "${_DEPLOY_ENV}--${_APP_NAME}", "--region", "us-west-2", "--cloudwatchregion", "us-west-1", "--workername", "MAGIC_ECS_TASK_ID", "--cmd", "/usr/bin/prune-images"]
+CMD ["/usr/bin/sfncli", "--activityname", "${_DEPLOY_ENV}--${_APP_NAME}", "--region", "us-west-2", "--cloudwatchregion", "${_POD_REGION}", "--workername", "MAGIC_ECS_TASK_ID", "--cmd", "/usr/bin/prune-images"]

--- a/launch/prune-images.yml
+++ b/launch/prune-images.yml
@@ -10,8 +10,8 @@ env:
 - DRY_RUN
 - MIN_IMAGES
 resources:
-  cpu: 0
-  max_mem: 0.1
+  cpu: 0.25
+  max_mem: 0.5
 shepherds:
 - vicky.enalen@clever.com
 expose: []
@@ -20,3 +20,9 @@ autoscaling:
   metric: active-percent
   metric_target: 70
   max_count: 1
+pod_config:
+  dev:
+    migrationState: podOnly
+  group: us-west-1
+  prod:
+    migrationState: homepod


### PR DESCRIPTION
This PR is the first step in migrating this worker to pods

This PR will
1. adjust cpu and memory values based to fit the fargate constraints
2. deploy the dev version of the worker to pods

After merging this PR once the deploy is complete
1. `ark start --upstreams -e clever-dev <app>`
2. Verify deploy was succesful and that there were no container exits. This can be done by looking at container count in grafana (go/workers)
3. If critical app then also run some production like workloads

In case of errors
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e production <appName>`
