### PR TITLE
prod to podOnly

### DIFF
--- a/launch/prune-images.yml
+++ b/launch/prune-images.yml
@@ -25,4 +25,4 @@ pod_config:
     migrationState: podOnly
   group: us-west-1
   prod:
-    migrationState: homepod
+    migrationState: podOnly


### PR DESCRIPTION
This PR is the second step in migrating this worker to pods

This PR will deploy the worker to pods in prod. Going forward all work is split by homepod and pod deployment at random

After merging this PR once the deploy is complete
1. `ark start --upstreams -e production <appName>` 3-5 mins for all apps
2. Verify deploy was succesfull (i.e no container exits. can be done by looking at container count in grafana) 5-10 mins for all apps
3. contact #oncall-infra to do next step

In case of errors
1. revert this PR
2. merge the deploy
3. `ark start --upstreams -e production <appName>`
