### PR TITLE
remove autoscaling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* vicky.enalen@clever.com
+* @Clever/eng-infra

--- a/launch/prune-images.yml
+++ b/launch/prune-images.yml
@@ -16,10 +16,6 @@ shepherds:
 - vicky.enalen@clever.com
 expose: []
 team: eng-infra
-autoscaling:
-  metric: active-percent
-  metric_target: 70
-  max_count: 1
 pod_config:
   dev:
     migrationState: podOnly


### PR DESCRIPTION
My deploy to production in pods failed with the following error

```Deploy failed: The deployment failed: The following pods encountered errors:
    a6127c9c-2be8-4078-8c00-132d29fbecfc - failed to execute change set type - CREATE, name - production--prune-images--a6127c9c-CREATE-1619468617: Maximum capacity cannot be less than minimum capacity (Service: AWSApplicationAutoScaling; Status Code: 400; Error Code: ValidationException; Request ID: 16bb5900-bb5a-427f-a067-88f24834f601; Proxy: null)```

We had `max_count = 1` along with `autoscaling` which doesn't make sense. Lets just remove the `autoscaling` block