### PR TITLE
both to noHomepod

### DIFF
--- a/launch/prune-images.yml
+++ b/launch/prune-images.yml
@@ -17,8 +17,4 @@ shepherds:
 expose: []
 team: eng-infra
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
This PR is the last step in migrating this worker to pods

We have already migrated the worker to pod in dev and prod so there are no risks in this PR.
After merging this PR we will stop deploying to homepod

After merging this PR once the deploy is complete run
1. `ark stop <app> -e clever-dev --kill-homepod`
2. `ark stop <app> -e production --kill-homepod`
