### PR TITLE
upgrade to go 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/prune-images
     docker:
-    - image: cimg/go:1.16
+    - image: cimg/go:1.21
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm-slim
 RUN apt-get update -y
 RUN apt-get install -y ca-certificates
 COPY bin/prune-images /usr/bin/prune-images

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SFNCLI_VERSION := latest
 
 .PHONY: test $(PKGS) run
 
-$(eval $(call golang-version-check,1.16))
+$(eval $(call golang-version-check,1.21))
 
 test: $(PKGS)
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,17 @@
 module github.com/Clever/prune-images
 
-go 1.16
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.37.1
+	gopkg.in/Clever/kayvee-go.v6 v6.26.0
+)
+
+require (
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180407105557-2c8e4be869c1 // indirect
-	gopkg.in/Clever/kayvee-go.v6 v6.26.0
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.0.1
+GOLANG_MK_VERSION := 1.2.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -47,6 +47,8 @@ golang-ensure-curl-installed:
 # Golint is a tool for linting Golang code for common errors.
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
+# this package is deprecated and frozen
+# Infra recomendation is to eventaully move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
@@ -74,14 +76,6 @@ endef
 # golang-lint-deps-strict requires the golint tool for golang linting.
 golang-lint-deps-strict: $(GOLINT) $(FGT)
 
-# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
-# errors are found.
-# arg1: pkg path
-define golang-lint-strict
-@echo "LINTING $(1)..."
-@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); find $${PKG_PATH}/*.go -type f | grep -v gen_ | xargs $(FGT) $(GOLINT)
-endef
-
 # golang-test-deps is here for consistency
 golang-test-deps:
 
@@ -100,6 +94,21 @@ golang-test-strict-deps:
 define golang-test-strict
 @echo "TESTING $(1)..."
 @go test -v -race $(1)
+endef
+
+# golang-test-strict-cover-deps is here for consistency
+golang-test-strict-cover-deps:
+
+# golang-test-strict-cover uses the Go toolchain to run all tests in the pkg with the race and cover flag.
+# appends coverage results to coverage.txt
+# arg1: pkg path
+define golang-test-strict-cover
+@echo "TESTING $(1)..."
+@go test -v -race -cover -coverprofile=profile.tmp -covermode=atomic $(1)
+@if [ -f profile.tmp ]; then \
+  cat profile.tmp | tail -n +2 >> coverage.txt; \
+  rm profile.tmp; \
+fi;
 endef
 
 # golang-vet-deps is here for consistency
@@ -132,16 +141,29 @@ golang-test-all-strict-deps: golang-fmt-deps golang-lint-deps-strict golang-test
 # arg1: pkg path
 define golang-test-all-strict
 $(call golang-fmt,$(1))
-$(call golang-lint-strict,$(1))
+$(call golang-lint,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
+endef
+
+# golang-test-all-strict-cover-deps: installs all dependencies needed for different test cases.
+golang-test-all-strict-cover-deps: golang-fmt-deps golang-lint-deps-strict golang-test-strict-cover-deps golang-vet-deps
+
+# golang-test-all-strict-cover calls fmt, lint, vet and test on the specified pkg with strict and cover
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict-cover
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test-strict-cover,$(1))
 endef
 
 # golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
 # arg1: pkg path
 # arg2: executable name
 define golang-build
-@echo "BUILDING..."
+@echo "BUILDING $(2)..."
 @if [ -z "$$CI" ]; then \
 	go build -o bin/$(2) $(1); \
 else \
@@ -149,6 +171,10 @@ else \
 	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
 fi;
 endef
+
+# golang-setup-coverage: set up the coverage file
+golang-setup-coverage:
+	@echo "mode: atomic" > coverage.txt
 
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:

--- a/sfncli.mk
+++ b/sfncli.mk
@@ -1,10 +1,13 @@
 # This is the default sfncli Makefile.
 # Please do not alter this file directly.
-SFNCLI_MK_VERSION := 0.1.1
+SFNCLI_MK_VERSION := 0.1.2
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
-SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest | grep tag_name | cut -d\" -f4)
+# AUTH_HEADER is used to help avoid github ratelimiting
+AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
+SFNCLI_LATEST = $(shell \
+	curl -f -s https://api.github.com/repos/Clever/sfncli/releases | jq -r 'map(select(.prerelease)) | .[0].tag_name')
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 
@@ -21,14 +24,21 @@ bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
 	@mkdir -p bin
 	$(eval SFNCLI_VERSION := $(if $(filter latest,$(SFNCLI_VERSION)),$(SFNCLI_LATEST),$(SFNCLI_VERSION)))
 	@echo "Checking for sfncli updates..."
+	@# AUTH_HEADER not added to curl command below because it doesn't play well with redirects
 	@if [[ "$(SFNCLI_VERSION)" == "$(SFNCLI_INSTALLED)" ]]; then \
-		echo "Using latest sfncli version $(SFNCLI_VERSION)"; \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to download sfncli.  Try setting GITHUB_API_TOKEN"; exit 1; } || \
+			{ echo "Using latest sfncli version $(SFNCLI_VERSION)"; } \
+		} \
 	else \
 		echo "Updating sfncli..."; \
 		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && \
 		chmod +x bin/sfncli && \
-		echo "Successfully updated sfncli to $(SFNCLI_LATEST)" || \
-		{ echo "Failed to update sfncli"; exit 1; } \
+		echo "Successfully updated sfncli to $(SFNCLI_VERSION)" || \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to update sfncli"; exit 1; } || \
+			{ echo "⚠️  Warning: Failed to update sfncli using pre-existing version"; } \
+		} \
 	;fi
 
 sfncli-update-makefile: ensure-curl-installed


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRANG-5737

**Overview:**
This is a combination of the go 1.21 upgrade, + sfncli and docker changes needed to avoid the glibc issue. This had to be rebased on master to avoid go.mod changes being overwritten and downgrading imports accidentally. 

**Testing:**
For this batch I will NOT be asking teams to deploy and test these changes. I will be doing that myself.
I will also be asking Infra to batch approve these instead of waiting on the teams. 
At this point we've gained a pretty high confidence in these changes and the standard failure modes. 

**Roll Out:**
Once this is merged and all other workers are merged I will be able to update sfncli master, and then go back and change the sfncli.mk code to grab "latest" again instead of the "pre-release". 
