### PR TITLE
Update sfncli.mk

### DIFF
--- a/sfncli.mk
+++ b/sfncli.mk
@@ -6,8 +6,7 @@ SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
 # AUTH_HEADER is used to help avoid github ratelimiting
 AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
-SFNCLI_LATEST = $(shell \
-	curl -f -s https://api.github.com/repos/Clever/sfncli/releases | jq -r 'map(select(.prerelease)) | .[0].tag_name')
+SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest  | grep tag_name | cut -d\" -f4)
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRANG-6510

**Overview:**
This is a combination of the go 1.21 upgrade, + sfncli and docker changes needed to avoid the glibc issue. This had to be rebased on master to avoid go.mod changes being overwritten and downgrading imports accidentally. 


**Testing:**
`make test` run locally and then deployed into private environment. After ensuring there were no logged errors and specifically looking for anything around glibc this is safe to merge. 


**Roll Out:**
Once this is merged and all other workers are merged I will be able to update sfncli master, and then go back and change the sfncli.mk code to grab "latest" again instead of the "pre-release".